### PR TITLE
chore: update CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @open-turo/android
+* @open-turo/nibel-maintainers


### PR DESCRIPTION
Update CODEOWNERS to @open-turo/nibel-maintainers 