### PR TITLE
ci: fixes github token used for ci release workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -45,7 +45,7 @@ jobs:
       - uses: open-turo/actions-jvm/release@v2
         with:
           checkout-repo: true
-          github-token: ${{ secrets.OPEN_TURO_GITHUB_TOKEN }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
         env:
           ORG_GRADLE_PROJECT_artifactoryUsername: ${{ secrets.ARTIFACTORY_USERNAME }}
           ORG_GRADLE_PROJECT_artifactoryAuthToken: ${{ secrets.ARTIFACTORY_PASSWORD }}


### PR DESCRIPTION

**Description**


Previous workflow failed for using the wrong token:
https://github.com/open-turo/nibel/actions/runs/22493158334/job/65160841476


**Changes**

* ci: fixes github token used for ci release workflow

🚀 PR created with [fotingo](https://github.com/tagoro9/fotingo)