### PR TITLE
fix: replace Gson with Parcel-based serialization for sealed class args

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -45,8 +45,7 @@ hilt-android-compiler = { module = "com.google.dagger:hilt-android-compiler", ve
 ksp-api = { module = "com.google.devtools.ksp:symbol-processing-api", version.ref = "ksp" }
 autoService-ksp = { group = "dev.zacsweers.autoservice", name = "auto-service-ksp", version.ref = "autoServiceKsp" }
 autoService-annotations = { group = "com.google.auto.service", name = "auto-service-annotations", version.ref = "autoService" }
-# ===== Serialization =====
-gson = "com.google.code.gson:gson:2.13.1"
+
 # ===== Tests =====
 junit = "junit:junit:4.12"
 kotest-assertions = "io.kotest:kotest-assertions-core:6.0.4"

--- a/nibel-runtime/build.gradle.kts
+++ b/nibel-runtime/build.gradle.kts
@@ -14,5 +14,5 @@ dependencies {
     api(projects.nibelAnnotations)
     implementation(libs.androidx.compose.navigation)
     implementation(libs.androidx.fragment)
-    implementation(libs.gson)
+
 }

--- a/nibel-runtime/src/main/kotlin/nibel/runtime/Serializer.kt
+++ b/nibel-runtime/src/main/kotlin/nibel/runtime/Serializer.kt
@@ -1,20 +1,39 @@
 package nibel.runtime
 
 import android.net.Uri
+import android.os.Parcel
 import android.os.Parcelable
-import com.google.gson.Gson
+import android.util.Base64
 
 class Serializer {
 
-    private val gson by lazy {
-        Gson()
+    fun <P : Parcelable> serialize(value: P): String {
+        val parcel = Parcel.obtain()
+        try {
+            parcel.writeParcelable(value, 0)
+            val bytes = parcel.marshall()
+            val base64 = Base64.encodeToString(bytes, Base64.URL_SAFE or Base64.NO_WRAP)
+            return Uri.encode(base64)
+        } finally {
+            parcel.recycle()
+        }
     }
 
-    fun <P : Parcelable> serialize(value: P): String =
-        Uri.encode(gson.toJson(value))
-
-    fun <P : Parcelable> deserialize(value: String, type: Class<P>): P =
-        gson.fromJson(value, type)
+    @Suppress("DEPRECATION")
+    fun <P : Parcelable> deserialize(value: String, type: Class<P>): P {
+        val bytes = Base64.decode(value, Base64.URL_SAFE or Base64.NO_WRAP)
+        val parcel = Parcel.obtain()
+        try {
+            parcel.unmarshall(bytes, 0, bytes.size)
+            parcel.setDataPosition(0)
+            val result = parcel.readParcelable<P>(type.classLoader)
+            return result ?: throw IllegalArgumentException(
+                "Failed to deserialize Parcelable of type ${type.name}",
+            )
+        } finally {
+            parcel.recycle()
+        }
+    }
 }
 
 inline fun <reified P : Parcelable> Serializer.deserialize(value: String): P =

--- a/sample/feature-A/src/main/kotlin/com/turo/nibel/sample/featureA/firstscreen/FirstScreen.kt
+++ b/sample/feature-A/src/main/kotlin/com/turo/nibel/sample/featureA/firstscreen/FirstScreen.kt
@@ -9,6 +9,7 @@ import com.turo.nibel.sample.common.SideEffectHandler
 import com.turo.nibel.sample.featureA.secondscreen.SecondArgs
 import com.turo.nibel.sample.featureA.secondscreen.SecondScreenEntry
 import com.turo.nibel.sample.navigation.FirstScreenDestination
+import com.turo.nibel.sample.navigation.Input
 import kotlinx.coroutines.flow.Flow
 import nibel.annotations.ImplementationType
 import nibel.annotations.UiExternalEntry
@@ -41,7 +42,7 @@ private fun SideEffectHandler(sideEffects: Flow<FirstSideEffect>) {
         when (it) {
             is FirstSideEffect.NavigateBack -> navigateBack()
             is FirstSideEffect.NavigateToSecondScreen -> {
-                val args = SecondArgs(it.inputText)
+                val args = SecondArgs(Input.Text(it.inputText))
                 navigateTo(SecondScreenEntry.newInstance(args))
             }
         }

--- a/sample/feature-A/src/main/kotlin/com/turo/nibel/sample/featureA/secondscreen/SecondScreen.kt
+++ b/sample/feature-A/src/main/kotlin/com/turo/nibel/sample/featureA/secondscreen/SecondScreen.kt
@@ -8,6 +8,7 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.turo.nibel.sample.common.CommonScreen
 import com.turo.nibel.sample.common.SideEffectHandler
 import com.turo.nibel.sample.featureA.externalcontent.ExternalContentDemoScreenEntry
+import com.turo.nibel.sample.navigation.Input
 import com.turo.nibel.sample.navigation.ThirdArgs
 import com.turo.nibel.sample.navigation.ThirdScreenDestination
 import kotlinx.coroutines.flow.Flow
@@ -43,9 +44,10 @@ private fun SideEffectHandler(sideEffects: Flow<SecondSideEffect>) {
         when (it) {
             is SecondSideEffect.NavigateBack -> navigateBack()
             is SecondSideEffect.NavigateToThirdScreen -> {
-                val args = ThirdArgs(it.inputText)
+                val args = ThirdArgs(input = Input.Text(inputText = it.inputText))
                 navigateTo(ThirdScreenDestination(args))
             }
+
             is SecondSideEffect.NavigateToExternalContentDemo -> {
                 navigateTo(ExternalContentDemoScreenEntry.newInstance())
             }
@@ -54,4 +56,4 @@ private fun SideEffectHandler(sideEffects: Flow<SecondSideEffect>) {
 }
 
 @Parcelize
-data class SecondArgs(val inputText: String) : Parcelable
+data class SecondArgs(val input: Input) : Parcelable

--- a/sample/feature-A/src/main/kotlin/com/turo/nibel/sample/featureA/secondscreen/SecondViewModel.kt
+++ b/sample/feature-A/src/main/kotlin/com/turo/nibel/sample/featureA/secondscreen/SecondViewModel.kt
@@ -18,7 +18,7 @@ class SecondViewModel @Inject constructor(
     val sideEffects: Flow<SecondSideEffect> get() = _sideEffects
 
     private val _state = MutableStateFlow(
-        SecondState(inputText = savedStateHandle.getNibelArgs<SecondArgs>()!!.inputText),
+        SecondState(inputText = savedStateHandle.getNibelArgs<SecondArgs>()!!.input.toString()),
     )
     val state: StateFlow<SecondState> get() = _state
 

--- a/sample/feature-A/src/main/kotlin/com/turo/nibel/sample/featureA/zeroscreen/ZeroFragment.kt
+++ b/sample/feature-A/src/main/kotlin/com/turo/nibel/sample/featureA/zeroscreen/ZeroFragment.kt
@@ -69,7 +69,8 @@ class ZeroFragment : CommonScreenFragment() {
             }
 
             is ZeroSideEffect.NavigateToThirdScreen -> fragmentManager.commit {
-                val destination = ThirdScreenDestination(ThirdArgs(inputText = ""))
+                val destination =
+                    ThirdScreenDestination(ThirdArgs(input = com.turo.nibel.sample.navigation.Input.Nothing))
                 val fragment = Nibel.newFragmentEntry(destination)?.fragment
                 if (fragment == null) {
                     showErrorMessage(destination)

--- a/sample/feature-B/src/main/kotlin/com/turo/nibel/sample/featureB/thirdscreen/ThirdViewModel.kt
+++ b/sample/feature-B/src/main/kotlin/com/turo/nibel/sample/featureB/thirdscreen/ThirdViewModel.kt
@@ -19,7 +19,7 @@ class ThirdViewModel @Inject constructor(
     val sideEffects: Flow<ThirdSideEffect> get() = _sideEffects
 
     private val _state = MutableStateFlow(
-        ThirdState(inputText = savedStateHandle.getNibelArgs<ThirdArgs>()!!.inputText),
+        ThirdState(inputText = savedStateHandle.getNibelArgs<ThirdArgs>()!!.input.toString()),
     )
     val state: StateFlow<ThirdState> get() = _state
 

--- a/sample/navigation/src/main/kotlin/com/turo/nibel/sample/navigation/FeatureBNavigation.kt
+++ b/sample/navigation/src/main/kotlin/com/turo/nibel/sample/navigation/FeatureBNavigation.kt
@@ -5,7 +5,7 @@ import kotlinx.parcelize.Parcelize
 import nibel.annotations.DestinationWithArgs
 
 @Parcelize
-data class ThirdArgs(val inputText: String) : Parcelable
+data class ThirdArgs(val input: Input) : Parcelable
 
 data class ThirdScreenDestination(override val args: ThirdArgs) : DestinationWithArgs<ThirdArgs>
 
@@ -13,3 +13,14 @@ data class ThirdScreenDestination(override val args: ThirdArgs) : DestinationWit
 data class FifthArgs(val label: String) : Parcelable
 
 data class FifthScreenDestination(override val args: FifthArgs) : DestinationWithArgs<FifthArgs>
+
+@Parcelize
+sealed class Input : Parcelable {
+    data class Text(val inputText: String) : Input() {
+        override fun toString(): String = inputText
+    }
+
+    data object Nothing : Input() {
+        override fun toString(): String = ""
+    }
+}


### PR DESCRIPTION
## Summary
- Replace Gson serialization in `Serializer.kt` with Android's native Parcel mechanism (Parcel → byte[] → Base64 URL-safe) to support sealed classes/interfaces as navigation arguments
- Remove the Gson dependency from `nibel-runtime`
- Update the sample app to demonstrate sealed class args working end-to-end via the `Input` sealed class

## Problem
When passing navigation arguments containing sealed classes through the Compose Navigation path, the app crashes with `JsonIOException: Abstract classes can't be instantiated!` because plain `Gson()` has no polymorphic type support. The Fragment navigation path (which uses `Bundle`/`Parcelable`) was unaffected.

## Solution
Since all nibel args are already `@Parcelize Parcelable`, we use `Parcel.writeParcelable()` / `readParcelable()` for serialization — which handles sealed class hierarchies correctly by definition. This also eliminates the Gson dependency entirely.

## Visual Evidence

| Before | After |
| --- | --- |
| <video src="https://github.com/user-attachments/assets/def19839-0224-4ac1-9771-753ed546b4a5"/> | <video src="https://github.com/user-attachments/assets/34750966-984b-4d23-b982-af6b8ff8297a"/> |



Jira: [ANDROID-17477](https://team-turo.atlassian.net/browse/ANDROID-17477)

