### PR TITLE
fix: add KSP 2 compatibility for class literal and enum annotation arguments

### DIFF
--- a/nibel-compiler/src/main/kotlin/nibel/compiler/generator/AbstractEntryGeneratingVisitor.kt
+++ b/nibel-compiler/src/main/kotlin/nibel/compiler/generator/AbstractEntryGeneratingVisitor.kt
@@ -5,7 +5,6 @@ import com.google.devtools.ksp.processing.Resolver
 import com.google.devtools.ksp.symbol.ClassKind
 import com.google.devtools.ksp.symbol.KSClassDeclaration
 import com.google.devtools.ksp.symbol.KSNode
-import com.google.devtools.ksp.symbol.KSType
 import com.google.devtools.ksp.symbol.KSTypeReference
 import com.google.devtools.ksp.symbol.KSVisitorVoid
 import com.google.devtools.ksp.symbol.Modifier
@@ -19,7 +18,8 @@ abstract class AbstractEntryGeneratingVisitor(
 ) : KSVisitorVoid() {
 
     protected fun Arguments.parseExternalEntry(symbol: KSNode): ExternalEntryMetadata? {
-        val arg = this["destination"] as KSType
+        // KSP 2: Class literal arguments may be KSClassDeclaration, not KSType.
+        val arg = this["destination"].asKSType()
         val destinationSimpleName = arg.declaration.simpleName
         val destinationPackageName = arg.declaration.packageName
         val destinationClassName = arg.declaration.qualifiedName!!
@@ -70,7 +70,8 @@ abstract class AbstractEntryGeneratingVisitor(
     }
 
     protected fun Arguments.parseInternalEntry(symbol: KSNode): InternalEntryMetadata? {
-        val arg = this["args"] as KSType
+        // KSP 2: Class literal arguments may be KSClassDeclaration, not KSType.
+        val arg = this["args"].asKSType()
         val declaration = arg.declaration as KSClassDeclaration
         if (!declaration.isCorrectArgsDeclaration(symbol)) {
             return null

--- a/nibel-compiler/src/main/kotlin/nibel/compiler/generator/EntryGeneratingVisitor.kt
+++ b/nibel-compiler/src/main/kotlin/nibel/compiler/generator/EntryGeneratingVisitor.kt
@@ -4,7 +4,6 @@ import com.google.devtools.ksp.processing.CodeGenerator
 import com.google.devtools.ksp.processing.KSPLogger
 import com.google.devtools.ksp.processing.Resolver
 import com.google.devtools.ksp.symbol.KSFunctionDeclaration
-import com.google.devtools.ksp.symbol.KSType
 import nibel.annotations.ImplementationType.Composable
 import nibel.annotations.ImplementationType.Fragment
 import nibel.annotations.UiEntry
@@ -37,7 +36,9 @@ class EntryGeneratingVisitor(
         }!!
 
         val arguments = annotation.arguments.toMap()
-        val implementationType = (arguments["type"] as KSType).asImplementationType()
+        // KSP 2: Enum entry arguments are KSClassDeclaration, not KSType.
+        // Use asImplementationType() which handles both.
+        val implementationType = arguments["type"].asImplementationType()
 
         val metadata = when (type) {
             ExternalEntry -> arguments.parseExternalEntry(function)?.run {

--- a/nibel-compiler/src/main/kotlin/nibel/compiler/generator/KsExtensions.kt
+++ b/nibel-compiler/src/main/kotlin/nibel/compiler/generator/KsExtensions.kt
@@ -1,7 +1,9 @@
 package nibel.compiler.generator
 
+import com.google.devtools.ksp.symbol.ClassKind
 import com.google.devtools.ksp.symbol.KSAnnotated
 import com.google.devtools.ksp.symbol.KSAnnotation
+import com.google.devtools.ksp.symbol.KSClassDeclaration
 import com.google.devtools.ksp.symbol.KSFunctionDeclaration
 import com.google.devtools.ksp.symbol.KSType
 import com.google.devtools.ksp.symbol.KSValueArgument
@@ -24,3 +26,36 @@ fun KSType.asImplementationType(): ImplementationType =
         ImplementationType.Composable.name -> ImplementationType.Composable
         else -> error("Unknown ${ImplementationType::class.qualifiedName}")
     }
+
+/**
+ * KSP 2 compatibility: Converts annotation argument values to [KSType].
+ * In KSP 2, class literal arguments may be returned as [KSClassDeclaration] instead of [KSType].
+ */
+fun Any?.asKSType(): KSType {
+    return when (this) {
+        is KSType -> this
+        is KSClassDeclaration -> asType(emptyList())
+        else -> error("Cannot convert ${this?.let { it::class.simpleName } ?: "null"} to KSType")
+    }
+}
+
+/**
+ * KSP 2 compatibility: Converts annotation argument values to [ImplementationType].
+ * In KSP 2, enum entry arguments are returned as [KSClassDeclaration] instead of [KSType].
+ */
+fun Any?.asImplementationType(): ImplementationType {
+    return when (this) {
+        is KSType -> asImplementationType()
+        is KSClassDeclaration -> {
+            check(classKind == ClassKind.ENUM_ENTRY) {
+                "Expected ENUM_ENTRY but got $classKind for ${qualifiedName?.asString()}"
+            }
+            when (simpleName.asString()) {
+                ImplementationType.Fragment.name -> ImplementationType.Fragment
+                ImplementationType.Composable.name -> ImplementationType.Composable
+                else -> error("Unknown ${ImplementationType::class.qualifiedName}: ${simpleName.asString()}")
+            }
+        }
+        else -> error("Cannot convert ${this?.let { it::class.simpleName } ?: "null"} to ImplementationType")
+    }
+}


### PR DESCRIPTION
## Summary

KSP 2 changes the types returned for annotation arguments:
- **Class literals** (e.g., `@UiEntry(args = MyArgs::class)`) are returned as `KSClassDeclaration` instead of `KSType`
- **Enum entries** (e.g., `@UiEntry(type = ImplementationType.Composable)`) are returned as `KSClassDeclaration` with `classKind == ENUM_ENTRY` instead of `KSType`

This causes `ClassCastException` at compile time for any project using Nibel with KSP 2 (which ships with Kotlin 2.1.20+).

### Changes

- **`KsExtensions.kt`**: Added two helper functions:
  - `asKSType()` — safely converts both `KSType` and `KSClassDeclaration` to `KSType`
  - `asImplementationType()` — handles enum entry resolution for both KSP 1 and KSP 2
- **`AbstractEntryGeneratingVisitor.kt`**: Replaced `as KSType` casts with `asKSType()` calls
- **`EntryGeneratingVisitor.kt`**: Replaced `as KSType` cast with `asImplementationType()` call

### Testing

Verified with a multi-module Android project (155+ modules) using AGP 9.0.1, Gradle 9.1.0, Kotlin 2.1.20, and KSP 2.1.20-1.0.32. All Nibel-annotated screens compile successfully with these changes.

### Motivation

This fix is needed to unblock the AGP 9 / Gradle 9 migration for projects depending on Nibel, as those Gradle versions ship with KSP 2 by default.