### PR TITLE
fix(ci): revert release workflow to use OPEN_TURO_GITHUB_TOKEN

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -41,15 +41,21 @@ jobs:
     name: Release
     runs-on: [ubuntu-latest]
     needs: [lint, test]
+    outputs:
+      new-release-published: ${{ steps.release.outputs.new-release-published }}
+      new-release-version: ${{ steps.release.outputs.new-release-version }}
     steps:
-      - uses: open-turo/actions-jvm/release@v2
+      - id: release
+        uses: open-turo/actions-jvm/release@v2
         with:
           checkout-repo: true
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+          github-token: ${{ secrets.OPEN_TURO_GITHUB_TOKEN }}
         env:
           ORG_GRADLE_PROJECT_artifactoryUsername: ${{ secrets.ARTIFACTORY_USERNAME }}
           ORG_GRADLE_PROJECT_artifactoryAuthToken: ${{ secrets.ARTIFACTORY_PASSWORD }}
-          # Maven Central publishing credentials
+          # Maven Central credentials are required for vanniktech's prepareMavenCentralPublishing
+          # validation task, which runs during ./gradlew publish even though the actual
+          # Central bundle upload happens in the downstream publish-to-central job.
           ORG_GRADLE_PROJECT_mavenCentralUsername: ${{ secrets.ARTIFACTORY_USERNAME }}
           ORG_GRADLE_PROJECT_mavenCentralPassword: ${{ secrets.ARTIFACTORY_PASSWORD }}
           # GPG signing
@@ -58,3 +64,31 @@ jobs:
           ORG_GRADLE_PROJECT_signingInMemoryKeyPassword: ${{ secrets.GPG_SIGNING_KEY_PASSWORD }}
           # Disable configuration cache for Maven Central publishing (gradle/gradle#22779)
           GRADLE_OPTS: "-Dorg.gradle.unsafe.configuration-cache=false"
+
+  publish-to-central:
+    name: Publish to Maven Central
+    needs: release
+    if: needs.release.outputs.new-release-published == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      # Check out the exact tag cut by semantic-release to avoid racing against
+      # any commit landing on main between the release job and this job.
+      - name: Checkout release tag
+        uses: actions/checkout@v6
+        with:
+          ref: v${{ needs.release.outputs.new-release-version }}
+
+      - name: Set up JDK
+        uses: open-turo/action-setup-tools@v3
+
+      - name: Setup Android SDK
+        uses: android-actions/setup-android@v3
+
+      - name: Publish to Maven Central
+        run: ./gradlew publishToMavenCentral --no-configuration-cache
+        env:
+          ORG_GRADLE_PROJECT_mavenCentralUsername: ${{ secrets.ARTIFACTORY_USERNAME }}
+          ORG_GRADLE_PROJECT_mavenCentralPassword: ${{ secrets.ARTIFACTORY_PASSWORD }}
+          ORG_GRADLE_PROJECT_signingInMemoryKey: ${{ secrets.GPG_SIGNING_KEY }}
+          ORG_GRADLE_PROJECT_signingInMemoryKeyId: ${{ secrets.GPG_SIGNING_KEY_ID }}
+          ORG_GRADLE_PROJECT_signingInMemoryKeyPassword: ${{ secrets.GPG_SIGNING_KEY_PASSWORD }}

--- a/build-tools/conventions/src/main/kotlin/NibelMavenPublishPlugin.kt
+++ b/build-tools/conventions/src/main/kotlin/NibelMavenPublishPlugin.kt
@@ -1,7 +1,6 @@
 import com.turo.nibel.buildtools.NibelConventionPlugin
 import com.turo.nibel.buildtools.libs
 import com.turo.nibel.buildtools.mavenPublishing
-import com.vanniktech.maven.publish.SonatypeHost
 
 class NibelMavenPublishPlugin : NibelConventionPlugin({
     with(pluginManager) {
@@ -42,7 +41,12 @@ class NibelMavenPublishPlugin : NibelConventionPlugin({
             }
         }
 
-        publishToMavenCentral(SonatypeHost.CENTRAL_PORTAL)
+        // SonatypeHost was removed in vanniktech 0.34.0; Central Portal is now the
+        // only supported host. Read mavenCentralAutomaticPublishing from gradle.properties
+        // to preserve the existing behaviour (currently true = auto-release after upload).
+        val automaticRelease = (project.findProperty("mavenCentralAutomaticPublishing") as String?)
+            ?.toBoolean() ?: false
+        publishToMavenCentral(automaticRelease = automaticRelease)
         val signingKey = project.findProperty("signingInMemoryKey") as String?
         if (!signingKey.isNullOrBlank()) {
             signAllPublications()

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -9,7 +9,7 @@ autoServiceKsp = "1.2.0"
 dagger = "2.56.2"
 lifecycle = "2.9.2"
 dokka = "1.8.20"
-mavenPublish = "0.33.0"
+mavenPublish = "0.34.0"
 detekt = "1.23.8"
 nibelConventionPlugin = "ignored"
 


### PR DESCRIPTION
## Summary

- Reverts `release.yaml` token from `GITHUB_TOKEN` back to `OPEN_TURO_GITHUB_TOKEN`
- The standard `GITHUB_TOKEN` cannot bypass branch protection on `main` (`enforce_admins: true`, requires PRs + status checks), so semantic-release's push of version bump commits was being rejected
- `OPEN_TURO_GITHUB_TOKEN` is the org-wide standard for release workflows — all other open-turo repos (`eslint-config`, `semantic-release-config`, `eslint-config-typescript`, etc.) use it in their `release.yaml`
- The regression was introduced in `444bf00`

## Test plan

- [ ] Merge and confirm the Release workflow completes successfully on the next push to `main`