### PR TITLE
feat!: migrate to Android Gradle Plugin 9

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ build
 .cxx
 local.properties
 .kotlin
+bin/

--- a/build-tools/conventions/build.gradle.kts
+++ b/build-tools/conventions/build.gradle.kts
@@ -10,8 +10,8 @@ java {
 }
 
 tasks.withType<KotlinCompile>().configureEach {
-    kotlinOptions {
-        jvmTarget = JavaVersion.VERSION_11.toString()
+    compilerOptions {
+        jvmTarget.set(org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_11)
     }
 }
 

--- a/build-tools/conventions/src/main/kotlin/NibelAndroidCommonPlugin.kt
+++ b/build-tools/conventions/src/main/kotlin/NibelAndroidCommonPlugin.kt
@@ -2,40 +2,25 @@ import com.turo.nibel.buildtools.CommonExtension
 import com.turo.nibel.buildtools.NibelConventionPlugin
 import com.turo.nibel.buildtools.android
 import com.turo.nibel.buildtools.implementation
-import com.turo.nibel.buildtools.kotlinOptions
 import com.turo.nibel.buildtools.libs
 import org.gradle.kotlin.dsl.dependencies
 import org.gradle.kotlin.dsl.withType
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 class NibelAndroidCommonPlugin : NibelConventionPlugin({
-    with(pluginManager) {
-        apply(libs.plugins.kotlin.android.get().pluginId)
-    }
-
     android<CommonExtension> {
         compileSdk = NibelMetadata.COMPILE_SDK
 
-        defaultConfig {
-            minSdk = NibelMetadata.MIN_SDK
+        defaultConfig.minSdk = NibelMetadata.MIN_SDK
+        defaultConfig.testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
 
-            testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
-        }
-
-        compileOptions {
-            sourceCompatibility = NibelMetadata.JAVA_VERSION
-            targetCompatibility = NibelMetadata.JAVA_VERSION
-        }
-        kotlinOptions {
-            jvmTarget = NibelMetadata.JAVA_VERSION.toString()
-            freeCompilerArgs = listOf(
-                "-Xstring-concat=inline"
-            )
-        }
+        compileOptions.sourceCompatibility = NibelMetadata.JAVA_VERSION
+        compileOptions.targetCompatibility = NibelMetadata.JAVA_VERSION
     }
 
-    tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile> {
-        kotlinOptions {
-            jvmTarget = NibelMetadata.JAVA_VERSION.toString()
+    tasks.withType<KotlinCompile>().configureEach {
+        compilerOptions {
+            freeCompilerArgs.addAll("-Xstring-concat=inline")
         }
     }
 

--- a/build-tools/conventions/src/main/kotlin/NibelAndroidCommonPlugin.kt
+++ b/build-tools/conventions/src/main/kotlin/NibelAndroidCommonPlugin.kt
@@ -20,6 +20,7 @@ class NibelAndroidCommonPlugin : NibelConventionPlugin({
 
     tasks.withType<KotlinCompile>().configureEach {
         compilerOptions {
+            jvmTarget.set(org.jetbrains.kotlin.gradle.dsl.JvmTarget.fromTarget(NibelMetadata.JAVA_VERSION.toString()))
             freeCompilerArgs.addAll("-Xstring-concat=inline")
         }
     }

--- a/build-tools/conventions/src/main/kotlin/NibelAndroidComposePlugin.kt
+++ b/build-tools/conventions/src/main/kotlin/NibelAndroidComposePlugin.kt
@@ -10,13 +10,7 @@ class NibelAndroidComposePlugin : NibelConventionPlugin({
         apply(libs.plugins.compose.compiler.get().pluginId)
     }
     android<CommonExtension> {
-        buildFeatures {
-            compose = true
-        }
-
-        composeOptions {
-            kotlinCompilerExtensionVersion = libs.versions.composeCompiler.get()
-        }
+        buildFeatures.compose = true
     }
 
     dependencies {

--- a/build-tools/conventions/src/main/kotlin/NibelKotlinJvmLibraryPlugin.kt
+++ b/build-tools/conventions/src/main/kotlin/NibelKotlinJvmLibraryPlugin.kt
@@ -11,8 +11,8 @@ class NibelKotlinJvmLibraryPlugin : NibelConventionPlugin({
     }
 
     tasks.withType<KotlinCompile>().configureEach {
-        kotlinOptions {
-            jvmTarget = NibelMetadata.JAVA_VERSION.toString()
+        compilerOptions {
+            jvmTarget.set(org.jetbrains.kotlin.gradle.dsl.JvmTarget.fromTarget(NibelMetadata.JAVA_VERSION.toString()))
         }
     }
 

--- a/build-tools/conventions/src/main/kotlin/SampleAndroidLibraryPlugin.kt
+++ b/build-tools/conventions/src/main/kotlin/SampleAndroidLibraryPlugin.kt
@@ -11,14 +11,8 @@ class SampleAndroidLibraryPlugin : NibelConventionPlugin({
     }
 
     android<CommonExtension> {
-        buildTypes {
-            getByName("release") {
-                isMinifyEnabled = true
-                proguardFiles(
-                    getDefaultProguardFile("proguard-android-optimize.txt"),
-                    "proguard-rules.pro"
-                )
-            }
+        buildTypes.getByName("release") {
+            isMinifyEnabled = false
         }
     }
 })

--- a/build-tools/conventions/src/main/kotlin/SampleAndroidLibraryPlugin.kt
+++ b/build-tools/conventions/src/main/kotlin/SampleAndroidLibraryPlugin.kt
@@ -12,7 +12,11 @@ class SampleAndroidLibraryPlugin : NibelConventionPlugin({
 
     android<CommonExtension> {
         buildTypes.getByName("release") {
-            isMinifyEnabled = false
+            isMinifyEnabled = true
+            proguardFiles(
+                getDefaultProguardFile("proguard-android-optimize.txt"),
+                "proguard-rules.pro",
+            )
         }
     }
 })

--- a/build-tools/conventions/src/main/kotlin/com/turo/nibel/buildtools/DslExtensions.kt
+++ b/build-tools/conventions/src/main/kotlin/com/turo/nibel/buildtools/DslExtensions.kt
@@ -8,29 +8,19 @@ import org.gradle.api.plugins.ExtensionAware
 import org.gradle.api.tasks.SourceSetContainer
 import org.gradle.kotlin.dsl.DependencyHandlerScope
 import org.gradle.kotlin.dsl.getByType
-import org.jetbrains.kotlin.gradle.dsl.KotlinJvmOptions
-import org.jetbrains.kotlin.gradle.dsl.KotlinSingleTargetExtension
-import org.jetbrains.kotlin.gradle.plugin.mpp.AbstractKotlinTarget
 
-typealias CommonExtension = com.android.build.api.dsl.CommonExtension<*, *, *, *, *, *>
+typealias CommonExtension = com.android.build.api.dsl.CommonExtension
 
 // Makes 'libs' version catalog available for precompiled plugins in a type-safe manner.
 // https://github.com/gradle/gradle/issues/15383#issuecomment-1245546796
 val Project.libs get() = extensions.getByType<LibrariesForLibs>()
 
-fun <T : CommonExtension> Project.android(body: T.() -> Unit) {
+fun <T : Any> Project.android(body: T.() -> Unit) {
     @Suppress("UNCHECKED_CAST")
     (extensions.getByName("android") as T).apply(body)
 }
 
-fun Project.kotlin(body: KotlinSingleTargetExtension<AbstractKotlinTarget>.() -> Unit): Unit =
-    (this as ExtensionAware).extensions.configure("kotlin", body)
-
-fun CommonExtension.kotlinOptions(body: KotlinJvmOptions.() -> Unit) {
-    (this as ExtensionAware).extensions.configure("kotlinOptions", body)
-}
-
-fun <T> NamedDomainObjectContainer<T>.release(body: T.() -> Unit) {
+fun <T : Any> NamedDomainObjectContainer<T>.release(body: T.() -> Unit) {
     getByName("release", body)
 }
 

--- a/build-tools/conventions/src/main/kotlin/com/turo/nibel/buildtools/DslExtensions.kt
+++ b/build-tools/conventions/src/main/kotlin/com/turo/nibel/buildtools/DslExtensions.kt
@@ -2,10 +2,8 @@ package com.turo.nibel.buildtools
 
 import com.vanniktech.maven.publish.MavenPublishBaseExtension
 import org.gradle.accessors.dm.LibrariesForLibs
-import org.gradle.api.NamedDomainObjectContainer
 import org.gradle.api.Project
 import org.gradle.api.plugins.ExtensionAware
-import org.gradle.api.tasks.SourceSetContainer
 import org.gradle.kotlin.dsl.DependencyHandlerScope
 import org.gradle.kotlin.dsl.getByType
 
@@ -15,18 +13,10 @@ typealias CommonExtension = com.android.build.api.dsl.CommonExtension
 // https://github.com/gradle/gradle/issues/15383#issuecomment-1245546796
 val Project.libs get() = extensions.getByType<LibrariesForLibs>()
 
-fun <T : Any> Project.android(body: T.() -> Unit) {
-    @Suppress("UNCHECKED_CAST")
+@Suppress("UNCHECKED_CAST")
+fun <T : CommonExtension> Project.android(body: T.() -> Unit) {
     (extensions.getByName("android") as T).apply(body)
 }
-
-fun <T : Any> NamedDomainObjectContainer<T>.release(body: T.() -> Unit) {
-    getByName("release", body)
-}
-
-val Project.sourceSets: SourceSetContainer
-    get() = (this as ExtensionAware).extensions
-        .getByName("sourceSets") as SourceSetContainer
 
 fun Project.mavenPublishing(configure: MavenPublishBaseExtension.() -> Unit) {
     (this as ExtensionAware).extensions.configure("mavenPublishing", configure)

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -2,13 +2,11 @@
 plugins {
     alias(libs.plugins.android.application) apply false
     alias(libs.plugins.android.library) apply false
-    alias(libs.plugins.kotlin.android) apply false
     alias(libs.plugins.ksp) apply false
     alias(libs.plugins.dagger.hilt.android) apply false
     alias(libs.plugins.dokka) apply false
     alias(libs.plugins.vanniktech.maven.publish) apply false
     alias(libs.plugins.kotlin.parcelize) apply false
-    alias(libs.plugins.kotlin.kapt) apply false
     alias(libs.plugins.kotlin.jvm) apply false
     alias(libs.plugins.detekt) apply false
     alias(libs.plugins.compose.compiler) apply false

--- a/docs/breaking-changes/v3.md
+++ b/docs/breaking-changes/v3.md
@@ -1,0 +1,144 @@
+# Breaking changes in v3
+
+## Description of changes
+
+This release upgrades the minimum required Android Gradle Plugin (AGP) version to **9.0.0**, which introduces breaking changes for consumers of this library. The update also includes Kotlin 2.3.0, KSP 2.3.6, and Hilt 2.59.2 to maintain compatibility with AGP 9.
+
+### Key Changes
+
+- **AGP 9.0.0 required**: Consumers must use AGP 9.0.0 or higher
+- **Gradle 9.1.0 required**: AGP 9 requires Gradle 9.1.0 or higher
+- **Kotlin 2.3.0 required**: Updated to maintain compatibility with AGP 9 built-in Kotlin
+- **KSP 2.3.6 required**: KSP versioning scheme changed in 2.3.x; old `KotlinVersion-KSPPatchVersion` format is incompatible with AGP 9
+- **`kotlin-android` plugin removed**: AGP 9 provides Kotlin support natively — manually applying `org.jetbrains.kotlin.android` is no longer needed and will cause conflicts
+- **`kotlin-kapt` plugin removed**: `kapt` is incompatible with AGP 9 built-in Kotlin; all annotation processors have been migrated to KSP
+- **Hilt 2.59.2 required**: Hilt ≤ 2.56.2 references `BaseExtension` which was removed in AGP 9
+
+## Upgrade instructions
+
+### Prerequisites
+
+- Android Studio Meerkat (2024.3.1) or newer (includes AGP 9 tooling support)
+- JDK 17 or higher
+- Gradle 9.1.0 or higher
+
+### Required Steps
+
+#### 1. Upgrade Android Gradle Plugin
+
+In your `libs.versions.toml` (or wherever you declare versions):
+
+```toml
+[versions]
+androidGradlePlugin = "9.0.0"
+kotlin = "2.3.0"
+ksp = "2.3.6"
+```
+
+#### 2. Upgrade Gradle wrapper
+
+In `gradle/wrapper/gradle-wrapper.properties`:
+
+```properties
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.1.0-bin.zip
+```
+
+#### 3. Remove `kotlin-android` plugin
+
+AGP 9 bundles Kotlin support. Remove all applications of `org.jetbrains.kotlin.android` from your modules:
+
+```kotlin
+// Before
+plugins {
+    id("com.android.library")
+    id("org.jetbrains.kotlin.android")  // ← remove this
+}
+
+// After
+plugins {
+    id("com.android.library")
+}
+```
+
+#### 4. Migrate `kapt` to `ksp`
+
+`kapt` is incompatible with AGP 9 built-in Kotlin. If you use Hilt, migrate to KSP:
+
+```toml
+# libs.versions.toml
+[versions]
+dagger = "2.59.2"
+ksp = "2.3.6"
+
+[plugins]
+ksp = { id = "com.google.devtools.ksp", version.ref = "ksp" }
+# Remove:
+# kotlin-kapt = { id = "org.jetbrains.kotlin.kapt", version.ref = "kotlin" }
+```
+
+```kotlin
+// build.gradle.kts — Before
+plugins {
+    id("com.android.application")
+    id("org.jetbrains.kotlin.kapt")
+    id("com.google.dagger.hilt.android")
+}
+
+dependencies {
+    kapt(libs.hilt.android.compiler)
+}
+
+// build.gradle.kts — After
+plugins {
+    id("com.android.application")
+    id("com.google.devtools.ksp")
+    id("com.google.dagger.hilt.android")
+}
+
+dependencies {
+    ksp(libs.hilt.android.compiler)
+}
+```
+
+#### 5. Replace `kotlinOptions` with `compilerOptions`
+
+`kotlinOptions {}` was removed in AGP 9. Use `compilerOptions {}` on `KotlinCompile` tasks instead:
+
+```kotlin
+// Before
+android {
+    kotlinOptions {
+        jvmTarget = "11"
+    }
+}
+
+// After
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
+
+tasks.withType<KotlinCompile>().configureEach {
+    compilerOptions {
+        jvmTarget.set(org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_11)
+    }
+}
+```
+
+#### 6. Fix missing proguard/consumer-rules files
+
+AGP 9 changed the default of `android.proguard.failOnMissingFiles` from `false` to `true`. If your `build.gradle.kts` references proguard files that don't exist on disk, the build will fail. Create the missing files (they can be empty):
+
+```bash
+touch proguard-rules.pro
+touch consumer-rules.pro
+```
+
+### Testing
+
+After upgrading:
+
+1. Run `./gradlew help` to verify configuration succeeds
+2. Run `./gradlew build --dry-run` to catch any remaining DSL issues
+3. Run `./gradlew build` for a full build verification
+
+### Rollback Plan
+
+If you encounter issues, you can pin to the previous nibel release (`2.x`) while investigating compatibility. The v2 branch remains compatible with AGP 8.x.

--- a/gradle.properties
+++ b/gradle.properties
@@ -10,11 +10,7 @@ org.gradle.unsafe.configuration-cache = true
 kotlin.caching.enabled = true
 kotlin.incremental = true
 kotlin.parallel.tasks.in.project = true
-android.defaults.buildfeatures.aidl = false
-android.defaults.buildfeatures.buildconfig = true
-android.defaults.buildfeatures.renderscript = false
-android.defaults.buildfeatures.resvalues = false
-android.defaults.buildfeatures.shaders = false
+
 android.enableResourceOptimizations = true
 android.nonFinalResIds = false
 # Maven Central publishing

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,12 +1,11 @@
 [versions]
 nibel = "1.0.4"
-androidGradlePlugin = "8.13.2"
-composeCompiler = "1.4.7"
-kotlin = "2.1.20"
-ksp = "2.1.20-1.0.32"
+androidGradlePlugin = "9.0.0"
+kotlin = "2.3.0"
+ksp = "2.3.6"
 autoService = "1.1.1"
 autoServiceKsp = "1.2.0"
-dagger = "2.56.2"
+dagger = "2.59.2"
 lifecycle = "2.9.2"
 dokka = "1.8.20"
 mavenPublish = "0.34.0"
@@ -63,13 +62,11 @@ detekt-formatting = { module = "io.gitlab.arturbosch.detekt:detekt-formatting", 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "androidGradlePlugin" }
 android-library = { id = "com.android.library", version.ref = "androidGradlePlugin" }
-kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
 ksp = { id = "com.google.devtools.ksp", version.ref = "ksp" }
 dagger-hilt-android = { id = "com.google.dagger.hilt.android", version.ref = "dagger" }
 dokka = { id = "org.jetbrains.dokka", version.ref = "dokka" }
 vanniktech-maven-publish = { id = "com.vanniktech.maven.publish", version.ref = "mavenPublish" }
 kotlin-jvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }
-kotlin-kapt = { id = "org.jetbrains.kotlin.kapt", version.ref = "kotlin" }
 kotlin-parcelize = { id = "org.jetbrains.kotlin.plugin.parcelize", version.ref = "kotlin" }
 detekt = { id = "io.gitlab.arturbosch.detekt", version.ref = "detekt" }
 compose-compiler = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-nibel = "1.0.4"
+nibel = "2.1.4"
 androidGradlePlugin = "9.0.0"
 kotlin = "2.3.0"
 ksp = "2.3.6"

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.4-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.1.0-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/nibel-compiler/src/main/kotlin/nibel/compiler/generator/EntryGeneratingVisitor.kt
+++ b/nibel-compiler/src/main/kotlin/nibel/compiler/generator/EntryGeneratingVisitor.kt
@@ -4,7 +4,6 @@ import com.google.devtools.ksp.processing.CodeGenerator
 import com.google.devtools.ksp.processing.KSPLogger
 import com.google.devtools.ksp.processing.Resolver
 import com.google.devtools.ksp.symbol.KSFunctionDeclaration
-import com.google.devtools.ksp.symbol.KSType
 import nibel.annotations.ImplementationType.Composable
 import nibel.annotations.ImplementationType.Fragment
 import nibel.annotations.UiEntry
@@ -37,7 +36,7 @@ class EntryGeneratingVisitor(
         }!!
 
         val arguments = annotation.arguments.toMap()
-        val implementationType = (arguments["type"] as KSType).asImplementationType()
+        val implementationType = arguments["type"]!!.asImplementationType()
 
         val metadata = when (type) {
             ExternalEntry -> arguments.parseExternalEntry(function)?.run {

--- a/nibel-compiler/src/main/kotlin/nibel/compiler/generator/EntryGeneratingVisitor.kt
+++ b/nibel-compiler/src/main/kotlin/nibel/compiler/generator/EntryGeneratingVisitor.kt
@@ -3,6 +3,7 @@ package nibel.compiler.generator
 import com.google.devtools.ksp.processing.CodeGenerator
 import com.google.devtools.ksp.processing.KSPLogger
 import com.google.devtools.ksp.processing.Resolver
+import com.google.devtools.ksp.symbol.KSClassDeclaration
 import com.google.devtools.ksp.symbol.KSFunctionDeclaration
 import nibel.annotations.ImplementationType.Composable
 import nibel.annotations.ImplementationType.Fragment
@@ -36,7 +37,7 @@ class EntryGeneratingVisitor(
         }!!
 
         val arguments = annotation.arguments.toMap()
-        val implementationType = arguments["type"]!!.asImplementationType()
+        val implementationType = (arguments["type"] as KSClassDeclaration).asImplementationType()
 
         val metadata = when (type) {
             ExternalEntry -> arguments.parseExternalEntry(function)?.run {

--- a/nibel-compiler/src/main/kotlin/nibel/compiler/generator/KsExtensions.kt
+++ b/nibel-compiler/src/main/kotlin/nibel/compiler/generator/KsExtensions.kt
@@ -2,6 +2,7 @@ package nibel.compiler.generator
 
 import com.google.devtools.ksp.symbol.KSAnnotated
 import com.google.devtools.ksp.symbol.KSAnnotation
+import com.google.devtools.ksp.symbol.KSClassDeclaration
 import com.google.devtools.ksp.symbol.KSFunctionDeclaration
 import com.google.devtools.ksp.symbol.KSType
 import com.google.devtools.ksp.symbol.KSValueArgument
@@ -18,9 +19,15 @@ fun KSFunctionDeclaration.isComposable(): Boolean =
 inline fun <reified A> KSAnnotated.findAnnotation(): KSAnnotation? =
     annotations.find { it.shortName.getShortName() == A::class.simpleName }
 
-fun KSType.asImplementationType(): ImplementationType =
-    when (declaration.simpleName.asString()) {
+fun Any.asImplementationType(): ImplementationType {
+    val name = when (this) {
+        is KSType -> declaration.simpleName.asString()
+        is KSClassDeclaration -> simpleName.asString()
+        else -> error("Unexpected enum value type: ${this::class}")
+    }
+    return when (name) {
         ImplementationType.Fragment.name -> ImplementationType.Fragment
         ImplementationType.Composable.name -> ImplementationType.Composable
         else -> error("Unknown ${ImplementationType::class.qualifiedName}")
     }
+}

--- a/nibel-compiler/src/main/kotlin/nibel/compiler/generator/KsExtensions.kt
+++ b/nibel-compiler/src/main/kotlin/nibel/compiler/generator/KsExtensions.kt
@@ -19,15 +19,15 @@ fun KSFunctionDeclaration.isComposable(): Boolean =
 inline fun <reified A> KSAnnotated.findAnnotation(): KSAnnotation? =
     annotations.find { it.shortName.getShortName() == A::class.simpleName }
 
-fun Any.asImplementationType(): ImplementationType {
-    val name = when (this) {
-        is KSType -> declaration.simpleName.asString()
-        is KSClassDeclaration -> simpleName.asString()
-        else -> error("Unexpected enum value type: ${this::class}")
-    }
-    return when (name) {
+fun KSType.asImplementationType(): ImplementationType =
+    declaration.simpleName.asString().toImplementationType()
+
+fun KSClassDeclaration.asImplementationType(): ImplementationType =
+    simpleName.asString().toImplementationType()
+
+private fun String.toImplementationType(): ImplementationType =
+    when (this) {
         ImplementationType.Fragment.name -> ImplementationType.Fragment
         ImplementationType.Composable.name -> ImplementationType.Composable
         else -> error("Unknown ${ImplementationType::class.qualifiedName}")
     }
-}

--- a/sample/app/build.gradle.kts
+++ b/sample/app/build.gradle.kts
@@ -2,7 +2,7 @@ plugins {
     alias(libs.plugins.sample.android.application)
     alias(libs.plugins.sample.android.compose)
     alias(libs.plugins.kotlin.parcelize)
-    alias(libs.plugins.kotlin.kapt)
+    alias(libs.plugins.ksp)
     alias(libs.plugins.dagger.hilt.android)
 }
 
@@ -30,5 +30,5 @@ dependencies {
     implementation(libs.nibel.runtime)
 
     implementation(libs.hilt.android)
-    kapt(libs.hilt.android.compiler)
+    ksp(libs.hilt.android.compiler)
 }

--- a/sample/common/proguard-rules.pro
+++ b/sample/common/proguard-rules.pro
@@ -1,0 +1,1 @@
+-dontwarn com.turo.nibel.sample.**

--- a/sample/common/proguard-rules.pro
+++ b/sample/common/proguard-rules.pro
@@ -1,1 +1,6 @@
+-dontobfuscate
+
+# Keep all public classes (referenced by feature modules across module boundaries)
+-keep class com.turo.nibel.sample.common.** { *; }
+
 -dontwarn com.turo.nibel.sample.**

--- a/sample/feature-A/build.gradle.kts
+++ b/sample/feature-A/build.gradle.kts
@@ -3,7 +3,6 @@ plugins {
     alias(libs.plugins.sample.android.compose)
     alias(libs.plugins.kotlin.parcelize)
     alias(libs.plugins.ksp)
-    alias(libs.plugins.kotlin.kapt)
     alias(libs.plugins.dagger.hilt.android)
 }
 
@@ -23,7 +22,7 @@ dependencies {
     implementation(libs.nibel.runtime)
     implementation(libs.hilt.android)
 
-    kapt(libs.hilt.android.compiler)
+    ksp(libs.hilt.android.compiler)
 
     ksp(libs.nibel.compiler)
 }

--- a/sample/feature-A/proguard-rules.pro
+++ b/sample/feature-A/proguard-rules.pro
@@ -1,0 +1,1 @@
+-dontwarn com.turo.nibel.sample.**

--- a/sample/feature-A/proguard-rules.pro
+++ b/sample/feature-A/proguard-rules.pro
@@ -1,1 +1,14 @@
+-dontobfuscate
+
+# Keep Hilt-generated code (referenced by app module's Dagger component)
+-keep class **_GeneratedInjector { *; }
+-keep class **_HiltModules* { *; }
+-keep class **_LazyMapKey { *; }
+
+# Keep ViewModels (injected by Hilt across module boundaries)
+-keep class * extends androidx.lifecycle.ViewModel { *; }
+
+# Keep Fragment subclasses (instantiated by class name)
+-keep class * extends androidx.fragment.app.Fragment { *; }
+
 -dontwarn com.turo.nibel.sample.**

--- a/sample/feature-B/build.gradle.kts
+++ b/sample/feature-B/build.gradle.kts
@@ -3,17 +3,11 @@ plugins {
     alias(libs.plugins.sample.android.compose)
     alias(libs.plugins.kotlin.parcelize)
     alias(libs.plugins.ksp)
-    alias(libs.plugins.kotlin.kapt)
     alias(libs.plugins.dagger.hilt.android)
 }
 
 android {
     namespace = "com.turo.nibel.sample.featureB"
-}
-
-// Allow references to generated code
-kapt {
-    correctErrorTypes = true
 }
 
 dependencies {
@@ -27,7 +21,7 @@ dependencies {
     implementation(libs.nibel.runtime)
     implementation(libs.hilt.android)
 
-    kapt(libs.hilt.android.compiler)
+    ksp(libs.hilt.android.compiler)
 
     ksp(libs.nibel.compiler)
 }

--- a/sample/feature-B/proguard-rules.pro
+++ b/sample/feature-B/proguard-rules.pro
@@ -1,0 +1,1 @@
+-dontwarn com.turo.nibel.sample.**

--- a/sample/feature-B/proguard-rules.pro
+++ b/sample/feature-B/proguard-rules.pro
@@ -1,1 +1,14 @@
+-dontobfuscate
+
+# Keep Hilt-generated code (referenced by app module's Dagger component)
+-keep class **_GeneratedInjector { *; }
+-keep class **_HiltModules* { *; }
+-keep class **_LazyMapKey { *; }
+
+# Keep ViewModels (injected by Hilt across module boundaries)
+-keep class * extends androidx.lifecycle.ViewModel { *; }
+
+# Keep Fragment subclasses (instantiated by class name)
+-keep class * extends androidx.fragment.app.Fragment { *; }
+
 -dontwarn com.turo.nibel.sample.**

--- a/sample/feature-C/build.gradle.kts
+++ b/sample/feature-C/build.gradle.kts
@@ -3,7 +3,6 @@ plugins {
     alias(libs.plugins.sample.android.compose)
     alias(libs.plugins.kotlin.parcelize)
     alias(libs.plugins.ksp)
-    alias(libs.plugins.kotlin.kapt)
     alias(libs.plugins.dagger.hilt.android)
 }
 
@@ -27,7 +26,7 @@ dependencies {
     implementation(libs.nibel.runtime)
     implementation(libs.hilt.android)
 
-    kapt(libs.hilt.android.compiler)
+    ksp(libs.hilt.android.compiler)
 
     ksp(libs.nibel.compiler)
 }

--- a/sample/feature-C/proguard-rules.pro
+++ b/sample/feature-C/proguard-rules.pro
@@ -1,0 +1,1 @@
+-dontwarn com.turo.nibel.sample.**

--- a/sample/feature-C/proguard-rules.pro
+++ b/sample/feature-C/proguard-rules.pro
@@ -1,1 +1,14 @@
+-dontobfuscate
+
+# Keep Hilt-generated code (referenced by app module's Dagger component)
+-keep class **_GeneratedInjector { *; }
+-keep class **_HiltModules* { *; }
+-keep class **_LazyMapKey { *; }
+
+# Keep ViewModels (injected by Hilt across module boundaries)
+-keep class * extends androidx.lifecycle.ViewModel { *; }
+
+# Keep Fragment subclasses (instantiated by class name)
+-keep class * extends androidx.fragment.app.Fragment { *; }
+
 -dontwarn com.turo.nibel.sample.**

--- a/sample/navigation/proguard-rules.pro
+++ b/sample/navigation/proguard-rules.pro
@@ -1,0 +1,1 @@
+-dontwarn com.turo.nibel.sample.**

--- a/sample/navigation/proguard-rules.pro
+++ b/sample/navigation/proguard-rules.pro
@@ -1,1 +1,6 @@
+-dontobfuscate
+
+# Keep all navigation classes (referenced by feature modules across module boundaries)
+-keep class com.turo.nibel.sample.navigation.** { *; }
+
 -dontwarn com.turo.nibel.sample.**


### PR DESCRIPTION
## Summary

- Upgrade AGP to 9.0.0, Gradle wrapper to 9.1.0, Kotlin to 2.3.0, KSP to 2.3.6, and Hilt to 2.59.2
- Remove `kotlin-android` and `kotlin-kapt` plugins — AGP 9 provides Kotlin natively; all annotation processing migrated to KSP
- Fix KSP 2.3.x breaking change: enum annotation arguments now return `KSClassDeclaration` instead of `KSType` in `nibel-compiler`
- Update convention plugins to AGP 9 DSL (`compilerOptions {}`, property-access style, no `composeOptions` block)
- Create missing proguard/consumer-rules files enforced by AGP 9's `failOnMissingFiles=true` default
- Add `docs/breaking-changes/v3.md` migration guide for consumers

Closes #72

## Test plan

- [x] `./gradlew help` passes
- [x] `./gradlew build --dry-run` passes
- [x] `./gradlew build` passes
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)